### PR TITLE
Help CocoaPods find our missing header file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build output:
 /android/build/
+/ios/libpiratelc.h
 /ios/libpiratelc.xcframework/
 /ios/PirateLightClientKit/
 /lib/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fixed: Add a missing header file to the podspec.
+
 ## 0.4.11 (2024-05-17)
 
 - fixed: Pause synchronizer events until JavaScript is ready to receive them.

--- a/ios/react-native-piratechain-Bridging-Header.h
+++ b/ios/react-native-piratechain-Bridging-Header.h
@@ -1,2 +1,2 @@
 #import <React/RCTEventEmitter.h>
-#include "PirateLightClientKit/Rust/libpiratelc.h"
+#include "libpiratelc.h"

--- a/react-native-piratechain.podspec
+++ b/react-native-piratechain.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
     :tag => "v#{s.version}"
   }
   s.source_files =
+    "ios/libpiratelc.h",
     "ios/react-native-piratechain-Bridging-Header.h",
     "ios/RNPiratechain.m",
     "ios/RNPiratechain.swift",

--- a/scripts/updateSources.ts
+++ b/scripts/updateSources.ts
@@ -112,7 +112,7 @@ async function copySwift(): Promise<void> {
 
   // Copy the Rust header into the Swift location:
   await disklet.setText(
-    'ios/PirateLightClientKit/Rust/libpiratelc.h',
+    'ios/libpiratelc.h',
     await disklet.getText(
       'tmp/pirate-light-client-ffi/releases/XCFramework/libpiratelc.xcframework/ios-arm64/libpiratelc.framework/Headers/piratelc.h'
     )


### PR DESCRIPTION
Compiling with `use_frameworks!` exposes the fact that we forgot to include libpiratelc.h in our podspec. Move it to a better location, then add it in.

See also https://github.com/EdgeApp/react-native-zcash/pull/54