### PR TITLE
Add more frequent update events during block download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- changed: (Android) Increase processor update frequency during block download
+
 ## 0.5.16 (2025-11-04)
 
 - changed: (Android) Update pirate dependencies to v1.19.0-beta04


### PR DESCRIPTION
The latest sdk goes silent for minutes at a time. This additional timer pulls the same data on an interval and stops once the synchronizer has caught up to network height. Once there, the actual emitter can just report on blockheight changes


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211641501376853